### PR TITLE
Priority Scheduler Feature Example

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/threadly"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>

--- a/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
+++ b/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
@@ -42,7 +42,7 @@ public class PrioritySchedulerExample {
    for (int i = 0; i < numThreads; i++) {
      //random between 0-2 to determine priority.
      TaskPriority priority = getRandomPriority();
-     System.out.println("Submitting thread " + (i + 1) + " with priority " + priority.toString());
+     System.out.println("Submitting thread " + (i) + " with priority " + priority.toString());
      futures.add(executor.submit(new BasicRunnable(i), priority));
    }
    
@@ -131,7 +131,7 @@ public class PrioritySchedulerExample {
         System.out.println("Thread "
                            + runNumber
                            + " is on iteration "
-                           + (i+1)
+                           + (i)
                            + ". ");
       }
       System.out.println("Thread " + runNumber + " took " + (System.nanoTime() - startTime) + "  nanoseconds to execute." );

--- a/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
+++ b/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
@@ -23,39 +23,33 @@ public final class PrioritySchedulerExample {
   
   /**
    * Provided a PriorityScheduler that contains some basic ideas
+   * @param executor -> a PriorityScheduler instance
    * @return -> the PriorityScheduler with tasks added
    */
-  public static PriorityScheduler getPriorityScheduler() {
+  public static PriorityScheduler addTasksToPriorityScheduler(PriorityScheduler executor) {
     final int numThreads = Runtime.getRuntime().availableProcessors() * 2;
-    final PriorityScheduler executor = new PriorityScheduler(numThreads);
     List<ListenableFuture<?>> futures = new ArrayList<ListenableFuture<?>>(numThreads);
     
-    futures.add(executor.submit(new Runnable() {
+    executor.scheduleWithFixedDelay(new Runnable() {
       
       @Override
       public void run() {
         /*
-         * This is the Starvable priority task that will be run.
-         * Starvable tasks run only when no other task needs to run
-         * It can be used to keep track of configuration:
-         * Example use case: closing sockets that no longer have hosts
-         * available on the other side.
+         * This is the task that will be run on a schedule.
+         * Example use case: A recurring task
          */
-        
       }
-    },
-    /*The priority of the task we are submitting*/TaskPriority.Starvable));
+    }, 0, 100000);
     
     futures.add(executor.submit(new Runnable() {
       
       @Override
       public void run() {
         /*
-         * This is the Low priority task that will be run.
-         * Low priority tasks are run before Starvable tasks,
-         * but exactly when it will be run is enforced by the 
-         * PrioritySchedulerService.
-         * Example use case: cache cleaning or other cleanup work
+         * This is a low priority task.
+         * Low priority is run before Starvable Priority tasks 
+         * and after High Priority tasks.
+         * Example: stats gathering for long running task
          */
         
       }
@@ -68,8 +62,8 @@ public final class PrioritySchedulerExample {
         /*
          * This is the High priority task that will be run.
          * High priority tasks are the highest priority in the thread pool.
-         * Example use case: Stats reporting about number of threads active in the pool
-         * and how many are queued.
+         * Example use case: Servicing requests for the application
+         * or doing processing that requires results as quickly as possible
          */
         
       } 
@@ -126,6 +120,19 @@ public final class PrioritySchedulerExample {
       e.printStackTrace();
     }
     return executor;
+  }
+  
+  /**
+   * prevents any future tasks from being submitted to the PriorityScheduler and does not run queued tasks
+   * @param executor -> the PriorityScheduler to operate on
+   * @param recurringStop -> whether or not to stop recurring tasks as well
+   */
+  public static void disposePrioritySchedulerTasks(final PriorityScheduler executor, boolean recurringStop) {
+    if (recurringStop) {
+      executor.shutdownNow();
+    } else {
+      executor.shutdownNow();
+    }
   }
   
   /**

--- a/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
+++ b/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
@@ -128,12 +128,11 @@ public final class PrioritySchedulerExample {
    * prevents any future tasks from being submitted to the PriorityScheduler
    * @param executor -> the PriorityScheduler to operate on
    * @param recurringStop -> whether or not to stop recurring tasks as well
-   * @param recurringTask -> the recurring task to remove if recurring stop is set, can be null
    */
-  public static void disposePrioritySchedulerTasks(final PriorityScheduler executor, boolean recurringStop, Runnable recurringTask) {
+  public void disposePrioritySchedulerTasks(final PriorityScheduler executor, boolean recurringStop) {
     if (recurringStop) {
-      if (recurringTask != null) {
-        executor.remove(recurringTask);
+      if (this.recurring != null) {
+        executor.remove(this.recurring);
       }
       executor.shutdown();
     } else {

--- a/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
+++ b/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
@@ -1,0 +1,70 @@
+package org.threadly.examples.features;
+
+/**
+ * Provides a basic example of the PriorityScheduler feature.
+ * 
+ * @author sreid8
+ *
+ */
+public class PrioritySchedulerExample {
+  
+  /**
+   * Main entry point of the example.
+   * @param args -> program args. run w/o args for help
+   */
+  public static void main(String[] args) {
+    if (args.length >= 1) {
+      printHelp();
+    }
+   }
+  
+  /**
+   * handles the args on startup
+   */
+  private static void handleArgs(final String[] args) {
+    //handles the args, decides whether to call help and validates data in args
+  }
+  
+  /**
+   * Prints the information
+   */
+  public static void printHelp() {
+    //the help information
+  }
+  
+  
+  /**
+   * This is a generic Runnable that the PriorityScheduler can run.
+   * 
+   */
+  private class BasicRunnable implements Runnable {
+    
+    /**
+     * the id of the thread which will be reported to stdout
+     */
+    private final int runNumber;
+
+    /**
+     * the time that the thread ended last time it executed
+     */
+    private long prevEndTime;
+    
+    /**
+     * Parameterized ctor 
+     * @param pRunNumber -> the id number of the thread which thread will report to stdout
+     */
+    public BasicRunnable(final int pRunNumber) {
+      this.runNumber = pRunNumber;
+    }
+    
+    @Override
+    public void run() {
+      for (int i = 0; i < 10; i++) {
+        //waste some time
+      }
+      //print time since last exe and thread id
+    }
+    
+  }
+  
+}

--- a/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
+++ b/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
@@ -2,12 +2,11 @@ package org.threadly.examples.features;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
+import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.concurrent.PriorityScheduler;
 import org.threadly.concurrent.TaskPriority;
-import org.threadly.concurrent.future.FutureUtils;
-import org.threadly.concurrent.future.ListenableFuture;
+
 
 /**
  * Provides a basic example of the PriorityScheduler feature.
@@ -15,150 +14,95 @@ import org.threadly.concurrent.future.ListenableFuture;
  * @author sreid8 - Sean Reid
  *
  */
-public class PrioritySchedulerExample {
-  
-  private static Boolean threadDetail = false;
-  
+public final class PrioritySchedulerExample {
   /**
-   * Main entry point of the example.
-   * @param args -> program args. run w/o args for help
+   * Provided a PriorityScheduler that contains some basic ideas
+   * @return -> the PriorityScheduler with tasks added
    */
-  public static void main(String[] args) {
-    if (!handleArgs(args)) {
-      System.exit(1);
-    }
+  public static PriorityScheduler getPriorityScheduler() {
+    final int numThreads = Runtime.getRuntime().availableProcessors() * 2;
+    final PriorityScheduler executor = new PriorityScheduler(numThreads);
+    List<ListenableFuture<?>> futures = new ArrayList<ListenableFuture<?>>(numThreads);
     
-    final int numThreads = Integer.parseInt(args[0]);
-    
-    //create the PriorityScheduler. This is where we will make a method to handle the case of different
-    //priorities!!!
-    final PriorityScheduler executor = new PriorityScheduler(numThreads - 1, true);
-    
-    //create a list of ListenableFutures (java.util.concurrent.Future + the ability to listen for
-    //completion of task) with the number of threads in the thread pool.
-    List<ListenableFuture<?>> futures = new ArrayList<ListenableFuture<?>>(numThreads - 1);
-    
-    //add numThreads - 1 tasks to the PriorityScheduler.
-   for (int i = 0; i <= numThreads; i++) {
-     //random between 0-2 to determine priority.
-     TaskPriority priority = getRandomPriority();
-     System.out.println("Submitting thread " + (i) + " with priority " + priority.toString());
-     futures.add(executor.submit(new BasicRunnable(i, threadDetail), priority));
-   }
-   /*
-    * Initialize the threads. This can be done BEFORE or AFTER submitting Runnables to the PriorityScheduler
-    * If done BEFORE:
-    *   Threads are created and are sitting idle. As soon as a task is submitted, an available thread will begin to work the task.
-    * If done AFTER:
-    *   Threads begin working on tasks immediately as they already have tasks.
-    */
-   executor.prestartAllThreads();
-   
-   //block until all threads are complete
-   try {
-     FutureUtils.blockTillAllCompleteOrFirstError(futures);
-   } catch (Exception e) {
-     //normally would be ExecutionException and InterrupedException
-     e.printStackTrace();
-   }
-
-    
-    
-   }
-  
-  /**
-   * handles the args on startup
-   */
-  private static Boolean handleArgs(final String[] args) {
-    //handles the args, decides whether to call help and validates data in args
-    try {
-      Integer.parseInt(args[0]);
-    } catch (NumberFormatException e) {
-      printHelp();
-      return false;
-    } catch (IndexOutOfBoundsException e) {
-      printHelp();
-      return false;
-    }
-    try {
-      if (args[1].equalsIgnoreCase("-v")) {
-        PrioritySchedulerExample.threadDetail = true;
+    futures.add(executor.submit(new Runnable() {
+      
+      @Override
+      public void run() {
+        /*
+         * This is the Starvable priority task that will be run.
+         * Starvable tasks run only when no other task needs to run
+         * It can be used to keep track of configuration:
+         * Example use case: closing sockets that no longer have hosts
+         * available on the other side.
+         */
+        
       }
-    } catch (IndexOutOfBoundsException e) {
-      PrioritySchedulerExample.threadDetail = false;
+    },
+    /*The priority of the task we are submitting*/TaskPriority.Starvable));
+    
+    futures.add(executor.submit(new Runnable() {
+      
+      @Override
+      public void run() {
+        /*
+         * This is the Low priority task that will be run.
+         * Low priority tasks are run before Starvable tasks,
+         * but exactly when it will be run is enforced by the 
+         * PrioritySchedulerService.
+         * Example use case: cache cleaning or other cleanup work
+         */
+        
+      }
+    }, TaskPriority.Low));
+    
+    futures.add(executor.submit(new Runnable() {
+
+      @Override
+      public void run() {
+        /*
+         * This is the High priority task that will be run.
+         * High priority tasks are the highest priority in the thread pool.
+         * Example use case: Stats reporting about number of threads active in the pool
+         * and how many are queued.
+         */
+        
+      } 
+     }, TaskPriority.High));
+    
+    //adding new high priority tasks to fill the pool
+    for (int i = 0; i < numThreads - 3; i++) {
+      futures.add(executor.submit(new HighPriorityTask(), TaskPriority.High));
     }
-    return true;
+    return executor;
   }
   
   /**
-   * Prints the information
-   */
-  public static void printHelp() {
-    System.out.println("Priority Scheduler Example executes a number of threads with a known, but randomly assigned. Each thread counts to the Max Integer Value before exiting.");
-    System.out.println("args: numThreads -> the integer numner of threads to be executed");
-    System.out.println("optional args: \"-v\" -> increases the amount of data reported by each thread and reduced the threads to counting to 100");
-    System.out.println("ex: PrioritySchedulerExample 1000 -v");
-  }
-  
-  /**
-   * gets a pseudorandom TaskPriority value
-   */
-  private static TaskPriority getRandomPriority() {
-    Random rand = new Random();
-    int randNum = rand.nextInt((2) + 1);
-    if (randNum == 0) {
-      return TaskPriority.Starvable;
-    } else if (randNum == 1) {
-      return TaskPriority.Low;
-    } else {
-      return TaskPriority.High;
-    }
-  }
-  
-  
-  /**
-   * This is a generic Runnable that the PriorityScheduler can run.
    * 
+   * @param executor -> a PriorityScheduler
+   * @return -> the same PriorityScheduler, but with the tasks started
    */
-  private static class BasicRunnable implements Runnable {
-    
-    /**
-     * the id of the thread which will be reported to stdout
+  public static PriorityScheduler startTasks(final PriorityScheduler executor) {
+    /*
+     * the prestartAllThreads() method can be called before or after
+     * tasks have been submitted
      */
-    private final int runNumber;
-    
-    /**
-     * the start time of the runnable
-     */
-    private final double startTime;
-    
-    /**
-     * whether or not to display detail
-     */
-    private final Boolean detail;
-    
-    /**
-     * Parameterized ctor. note: parameters are not required for a runnable to be executed by the PriorityScheduler.
-     * @param pRunNumber -> the id number of the thread which thread will report to stdout
-     * @param pDetail -> whether or not to show verbose output (suppress for large number of threads for readability)
-     */
-    public BasicRunnable(final int pRunNumber, final Boolean pDetail) {
-      this.runNumber = pRunNumber;
-      this.startTime = System.nanoTime();
-      this.detail = pDetail;
-    }
-    
+    executor.prestartAllThreads();
+    return executor;
+  }
+  
+  /**
+   * A basic runnable that can be reused
+   */
+  private static class HighPriorityTask implements Runnable {
+
     @Override
     public void run() {
-      for (int i = 0; i < (detail ? 100 : Integer.MAX_VALUE); i++) {
-        if (detail) {
-          System.out.println("Thread " + runNumber + " is on iteration " + (i) + ". ");
-        }
-      }
-      System.out.println("Thread " + runNumber + " took " + (System.nanoTime() - startTime) + "  nanoseconds to execute." );
+      /*
+       * A high priority task would be here. Something similar to the other
+       * High Priority task outlined above.
+       */
+      
     }
     
-    
   }
-  
 }

--- a/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
+++ b/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
@@ -112,11 +112,6 @@ public class PrioritySchedulerExample {
     private final int runNumber;
     
     /**
-     * the average execution time of the iterations
-     */
-    private double[] times;
-    
-    /**
      * the start time of the runnable
      */
     private final double startTime;
@@ -127,26 +122,19 @@ public class PrioritySchedulerExample {
      */
     public BasicRunnable(final int pRunNumber) {
       this.runNumber = pRunNumber;
-      this.times = new double[10];
       this.startTime = System.nanoTime();
     }
     
     @Override
     public void run() {
       for (int i = 0; i < 10; i++) {
-        
-        if (i == 0) {
-          times[i] = 0;
-        } else {
-          times[i] = System.nanoTime() - times[i-1];
-        }
-        System.out.print("Thread "
+        System.out.println("Thread "
                            + runNumber
                            + " is on iteration "
                            + (i+1)
                            + ". ");
       }
-      System.out.println("Thread " + runNumber + " took " + (startTime - System.nanoTime()) + " to execute." );
+      System.out.println("Thread " + runNumber + " took " + (System.nanoTime() - startTime) + "  nanoseconds to execute." );
     }
     
     

--- a/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
+++ b/src/main/java/org/threadly/examples/features/PrioritySchedulerExample.java
@@ -1,9 +1,18 @@
 package org.threadly.examples.features;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.threadly.concurrent.PriorityScheduler;
+import org.threadly.concurrent.TaskPriority;
+import org.threadly.concurrent.future.FutureUtils;
+import org.threadly.concurrent.future.ListenableFuture;
+
 /**
  * Provides a basic example of the PriorityScheduler feature.
  * 
- * @author sreid8
+ * @author sreid8 - Sean Reid
  *
  */
 public class PrioritySchedulerExample {
@@ -13,23 +22,81 @@ public class PrioritySchedulerExample {
    * @param args -> program args. run w/o args for help
    */
   public static void main(String[] args) {
-    if (args.length >= 1) {
-      printHelp();
+    if (!handleArgs(args)) {
+      System.exit(1);
     }
+    
+    final int numThreads = Integer.parseInt(args[0]);
+    
+    //create the PriorityScheduler. This is where we will make a method to handle the case of different
+    //priorities!!!
+    final PriorityScheduler executor = new PriorityScheduler(numThreads - 1, true);
+    //initialize all threads. threads will be idle until a task is provided
+    executor.prestartAllThreads();
+    
+    //create a list of ListenableFutures (java.util.concurrent.Future + the ability to listen for
+    //completion of task) with the number of threads in the thread pool.
+    List<ListenableFuture<?>> futures = new ArrayList<ListenableFuture<?>>(numThreads - 1);
+    
+    //add numThreads - 1 tasks to the PriorityScheduler.
+   for (int i = 0; i < numThreads; i++) {
+     //random between 0-2 to determine priority.
+     TaskPriority priority = getRandomPriority();
+     System.out.println("Submitting thread " + (i + 1) + " with priority " + priority.toString());
+     futures.add(executor.submit(new BasicRunnable(i), priority));
+   }
+   
+   //run the numThreads-th task on the main thread so that it is blocking.
+   BasicRunnable runner = new BasicRunnable(numThreads);
+   runner.run();
+   
+   //check to make sure that all the threads have completed
+   try {
+     FutureUtils.blockTillAllCompleteOrFirstError(futures);
+   } catch (Exception e) {
+     //normally would be ExecutionException and InterrupedException
+     e.printStackTrace();
+   }
+
+    
+    
    }
   
   /**
    * handles the args on startup
    */
-  private static void handleArgs(final String[] args) {
+  private static Boolean handleArgs(final String[] args) {
     //handles the args, decides whether to call help and validates data in args
+    try {
+      Integer.parseInt(args[0]);
+      //Integer.parseInt(args[1]);
+    } catch (NumberFormatException e) {
+      printHelp();
+    }
+    return true;
   }
   
   /**
    * Prints the information
    */
   public static void printHelp() {
-    //the help information
+    System.out.println("format: java -cp org.threadly.examples.features.PrioritySchedulerExample numberOfThreads priorityValue");
+    System.out.println("\nPriority Values:");
+  }
+  
+  /**
+   * gets a pseudorandom TaskPriority value
+   */
+  private static TaskPriority getRandomPriority() {
+    Random rand = new Random();
+    int randNum = rand.nextInt((2) + 1);
+    if (randNum == 0) {
+      return TaskPriority.Starvable;
+    } else if (randNum == 1) {
+      return TaskPriority.Low;
+    } else {
+      return TaskPriority.High;
+    }
   }
   
   
@@ -37,33 +104,51 @@ public class PrioritySchedulerExample {
    * This is a generic Runnable that the PriorityScheduler can run.
    * 
    */
-  private class BasicRunnable implements Runnable {
+  private static class BasicRunnable implements Runnable {
     
     /**
      * the id of the thread which will be reported to stdout
      */
     private final int runNumber;
-
-    /**
-     * the time that the thread ended last time it executed
-     */
-    private long prevEndTime;
     
     /**
-     * Parameterized ctor 
+     * the average execution time of the iterations
+     */
+    private double[] times;
+    
+    /**
+     * the start time of the runnable
+     */
+    private final double startTime;
+    
+    /**
+     * Parameterized ctor. note: parameters are not required for a runnable to be executed by the PriorityScheduler.
      * @param pRunNumber -> the id number of the thread which thread will report to stdout
      */
     public BasicRunnable(final int pRunNumber) {
       this.runNumber = pRunNumber;
+      this.times = new double[10];
+      this.startTime = System.nanoTime();
     }
     
     @Override
     public void run() {
       for (int i = 0; i < 10; i++) {
-        //waste some time
+        
+        if (i == 0) {
+          times[i] = 0;
+        } else {
+          times[i] = System.nanoTime() - times[i-1];
+        }
+        System.out.print("Thread "
+                           + runNumber
+                           + " is on iteration "
+                           + (i+1)
+                           + ". ");
       }
-      //print time since last exe and thread id
+      System.out.println("Thread " + runNumber + " took " + (startTime - System.nanoTime()) + " to execute." );
     }
+    
     
   }
   

--- a/src/main/java/org/threadly/examples/features/package-info.java
+++ b/src/main/java/org/threadly/examples/features/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * 
+ */
+/**
+ * @author sreid8
+ *
+ */
+package org.threadly.examples.features;

--- a/src/main/java/org/threadly/examples/features/package-info.java
+++ b/src/main/java/org/threadly/examples/features/package-info.java
@@ -1,8 +1,4 @@
 /**
- * 
- */
-/**
- * @author sreid8
- *
+ * A collection of small examples using specific threadly features.
  */
 package org.threadly.examples.features;


### PR DESCRIPTION
Per conversation with jentfoo, examples needed to be created for each of the [features on the threadly wiki.](https://github.com/threadly/threadly/wiki/Threadly-Features) The first of these to be attempted is the [PriorityScheduler](https://github.com/threadly/threadly/blob/master/src/main/java/org/threadly/concurrent/PriorityScheduler.java).

The example takes a number of threads as an argument. It creates that number of threads and tasks (simple counting task) and randomly assigns priorities to the tasks. All threads are then started at the same time and time from the start of the thread to the end of thread execution is reported when the thread terminates. "-v" can be passed to get additional detail about the status of execution of each thread.

Comments?